### PR TITLE
chore: Make clippy happy (minor cleanups)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -33,7 +33,7 @@ tasks:
 
   lint:
     cmds:
-      - cargo clippy --all -- -D clippy::dbg-macro -D warnings
+      - cargo clippy --examples --tests --benches --bins --lib --workspace -- -D clippy::pedantic -D clippy::dbg-macro -D warnings
 
   doc:
     cmds:

--- a/src/algorithms/cosine.rs
+++ b/src/algorithms/cosine.rs
@@ -23,8 +23,7 @@ impl Algorithm<f64> for Cosine {
         let n2 = c2.count();
         let res = match (n1, n2) {
             (0, 0) => 1.,
-            (_, 0) => 0.,
-            (0, _) => 0.,
+            (_, 0) | (0, _) => 0.,
             (_, _) => {
                 let ic = c1.intersect_count(&c2);
                 ic as f64 / ((n1 * n2) as f64).sqrt()

--- a/src/algorithms/damerau_levenshtein.rs
+++ b/src/algorithms/damerau_levenshtein.rs
@@ -50,11 +50,11 @@ impl DamerauLevenshtein {
 
         let mut mat: Vec<Vec<usize>> = vec![vec![0; l2 + 2]; l1 + 2];
         mat[0][0] = max_dist;
-        for i in 0..(l1 + 1) {
+        for i in 0..=l1 {
             mat[i + 1][0] = max_dist;
             mat[i + 1][1] = i;
         }
-        for i in 0..(l2 + 1) {
+        for i in 0..=l2 {
             mat[0][i + 1] = max_dist;
             mat[1][i + 1] = i;
         }
@@ -99,10 +99,10 @@ impl DamerauLevenshtein {
         let l2 = s2.len();
 
         let mut mat: Vec<Vec<usize>> = vec![vec![0; l2 + 2]; l1 + 2];
-        for i in 0..(l1 + 1) {
+        for i in 0..=l1 {
             mat[i][0] = i;
         }
-        for i in 0..(l2 + 1) {
+        for i in 0..=l2 {
             mat[0][i] = i;
         }
 

--- a/src/algorithms/hamming.rs
+++ b/src/algorithms/hamming.rs
@@ -58,6 +58,8 @@ impl Algorithm<usize> for Hamming {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::float_cmp)]
+
     use super::{Algorithm, Hamming};
     use crate::str::hamming;
     use assert2::assert;

--- a/src/algorithms/jaro.rs
+++ b/src/algorithms/jaro.rs
@@ -5,7 +5,7 @@ use crate::{Algorithm, Result};
 ///
 /// The metric is always normalized on the interval from 0.0 to 1.0.
 ///
-/// See also [JaroWinkler](crate::JaroWinkler).
+/// See also [`JaroWinkler`](crate::JaroWinkler).
 ///
 /// [Jaro similarity]: https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance#Jaro_similarity
 #[derive(Default)]

--- a/src/algorithms/jaro_winkler.rs
+++ b/src/algorithms/jaro_winkler.rs
@@ -23,7 +23,7 @@ pub struct JaroWinkler {
 impl Default for JaroWinkler {
     fn default() -> Self {
         Self {
-            jaro: Default::default(),
+            jaro: Jaro::default(),
             prefix_weight: 0.1,
             max_prefix: 4,
         }

--- a/src/algorithms/lcsseq.rs
+++ b/src/algorithms/lcsseq.rs
@@ -3,7 +3,7 @@ use crate::{Algorithm, Result};
 
 /// The length of the [Longest common subsequence].
 ///
-/// It differs from the [LCSStr](crate::LCSStr). Unlike substrings, subsequences are not required
+/// It differs from the [`LCSStr`](crate::LCSStr). Unlike substrings, subsequences are not required
 /// to occupy consecutive positions within the original sequences.
 ///
 /// [Longest common subsequence]: https://en.wikipedia.org/wiki/Longest_common_subsequence

--- a/src/algorithms/levenshtein.rs
+++ b/src/algorithms/levenshtein.rs
@@ -6,7 +6,7 @@ use crate::{Algorithm, Result};
 /// It is the minimum number of single-character edits (insertions, deletions or substitutions)
 /// required to change one word into the other.
 ///
-/// See also [DamerauLevenshtein](crate::DamerauLevenshtein) which is an extended
+/// See also [`DamerauLevenshtein`](crate::DamerauLevenshtein) which is an extended
 /// version of this algorithm that also includes transpositions.
 ///
 /// [Levenshtein distance]: https://en.wikipedia.org/wiki/Levenshtein_distance

--- a/src/algorithms/lig3.rs
+++ b/src/algorithms/lig3.rs
@@ -18,7 +18,7 @@ pub struct LIG3 {
 impl Default for LIG3 {
     fn default() -> Self {
         Self {
-            levenshtein: Default::default(),
+            levenshtein: Levenshtein::default(),
             #[allow(clippy::needless_update)]
             hamming: Hamming {
                 truncate: false,

--- a/src/algorithms/mlipns.rs
+++ b/src/algorithms/mlipns.rs
@@ -17,7 +17,7 @@ pub struct MLIPNS {
 impl Default for MLIPNS {
     fn default() -> Self {
         Self {
-            hamming: Default::default(),
+            hamming: Hamming::default(),
             threshold: 0.25,
             max_mismatches: 2,
         }
@@ -52,7 +52,7 @@ impl Algorithm<usize> for MLIPNS {
     {
         let ham = self.hamming.for_iter(s1, s2);
         Result {
-            abs: if self.check(&ham) { 1 } else { 0 },
+            abs: self.check(&ham).into(),
             is_distance: false,
             max: 1,
             len1: ham.len1,

--- a/src/algorithms/overlap.rs
+++ b/src/algorithms/overlap.rs
@@ -20,8 +20,7 @@ impl Algorithm<f64> for Overlap {
         let n2 = c2.count();
         let res = match (n1, n2) {
             (0, 0) => 1.,
-            (_, 0) => 0.,
-            (0, _) => 0.,
+            (_, 0) | (0, _) => 0.,
             (_, _) => {
                 let ic = c1.intersect_count(&c2);
                 ic as f64 / n1.min(n2) as f64

--- a/src/algorithms/ratcliff_obershelp.rs
+++ b/src/algorithms/ratcliff_obershelp.rs
@@ -1,7 +1,7 @@
 //! Gestalt pattern matching
 use crate::{Algorithm, Result};
 
-/// [Ratcliff/Obershelp similarity] is [LCSStr] that recursively finds matches
+/// [Ratcliff/Obershelp similarity] is [`LCSStr`] that recursively finds matches
 /// on both sides of the longest substring.
 ///
 /// The non-normalized result is a double number of matching characters defined as the first
@@ -79,6 +79,8 @@ impl Algorithm<usize> for RatcliffObershelp {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::float_cmp)]
+
     use super::{Algorithm, RatcliffObershelp};
     use crate::str::ratcliff_obershelp;
     use assert2::assert;

--- a/src/algorithms/sift4_common.rs
+++ b/src/algorithms/sift4_common.rs
@@ -4,7 +4,7 @@ use crate::{Algorithm, Result};
 /// [Sift4 distance] is an edit algorithm designed to be "fast and relatively accurate".
 ///
 /// The original blog post describes 3 different implementations of the algorithm,
-/// this is the "common" one. The main difference from [Sift4Simple](crate::Sift4Simple)
+/// this is the "common" one. The main difference from [`Sift4Simple`](crate::Sift4Simple)
 /// is the support for `max_distance` that can be used to stop calculating the distance
 /// after a certain threshold.
 ///

--- a/src/algorithms/smith_waterman.rs
+++ b/src/algorithms/smith_waterman.rs
@@ -45,6 +45,7 @@ impl Algorithm<usize> for SmithWaterman {
         }
         let result = dist_mat[l1][l2];
         Result {
+            #[allow(clippy::cast_sign_loss)]
             abs: result as usize,
             is_distance: false,
             max: l1.max(l2),

--- a/src/algorithms/tversky.rs
+++ b/src/algorithms/tversky.rs
@@ -2,7 +2,7 @@
 use crate::counter::Counter;
 use crate::{Algorithm, Result};
 
-/// [Tversky similarity] is a generalization of [SorensenDice] and [Jaccard].
+/// [Tversky similarity] is a generalization of [`SorensenDice`] and [Jaccard].
 ///
 /// [Tversky similarity]: https://en.wikipedia.org/wiki/Tversky_index
 /// [SorensenDice]: crate::SorensenDice

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,12 @@
-#![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![deny(missing_docs)]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::must_use_candidate,
+    clippy::similar_names,
+    clippy::unreadable_literal
+)]
 
 mod algorithm;
 mod counter;
@@ -66,6 +73,8 @@ pub use self::result::Result;
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use assert2::assert;
     use proptest::prelude::*;
@@ -217,8 +226,8 @@ mod tests {
         fn prop_prefix(prefix in ".+", s1 in ".+", s2 in ".+") {
             for alg in 1..ALGS {
                 let r1 = get_result(alg, &s1, &s2).ndist();
-                let mut p1 = prefix.to_owned();
-                let mut p2 = prefix.to_owned();
+                let mut p1 = prefix.clone();
+                let mut p2 = prefix.clone();
                 p1.push_str(&s1);
                 p2.push_str(&s2);
                 let r2 = get_result(alg, &p1, &p2).ndist();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::cast_precision_loss)]
+
 use std::borrow::Borrow;
 use textdistance::str;
 
@@ -12,5 +14,5 @@ fn main() {
         "roberts" => str::roberts(s1, s2),
         _ => panic!("unknown algorithm name"),
     };
-    println!("{}", res);
+    println!("{res}");
 }

--- a/src/nstr.rs
+++ b/src/nstr.rs
@@ -1,6 +1,6 @@
 //! Helper functions providing the default normalized implementation of distance/similarity algorithms for strings.
 //!
-//! See also [textdistance::str](super::str) for non-normalized distance.
+//! See also [`textdistance::str`](super::str) for non-normalized distance.
 
 use super::Algorithm;
 use super::Bag;
@@ -31,7 +31,7 @@ use super::MLIPNS;
 
 /// Calculate normalized unrestricted [Damerau-Levenshtein distance][1] for two strings.
 ///
-/// A wrapper for [DamerauLevenshtein].
+/// A wrapper for [`DamerauLevenshtein`].
 ///
 ///     use textdistance::nstr::damerau_levenshtein;
 ///     assert!(damerau_levenshtein("abc", "acbd") == 2./4.); // "bc" swapped and "d" added
@@ -43,7 +43,7 @@ pub fn damerau_levenshtein(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized restricted [Damerau-Levenshtein distance][1] for two strings.
 ///
-/// A wrapper for [DamerauLevenshtein].
+/// A wrapper for [`DamerauLevenshtein`].
 ///
 ///     use textdistance::nstr::damerau_levenshtein;
 ///     assert!(damerau_levenshtein("abc", "acbd") == 2./4.); // "bc" swapped and "d" added
@@ -71,7 +71,7 @@ pub fn hamming(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized the length of the [Longest Common SubSequence][1] for two strings.
 ///
-/// A wrapper for [LCSSeq].
+/// A wrapper for [`LCSSeq`].
 ///
 ///     use textdistance::nstr::lcsseq;
 ///     assert!(lcsseq("abcdef", "xbcegf") == 4./6.); // "bcef"
@@ -83,7 +83,7 @@ pub fn lcsseq(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized the length of the [Longest Common SubString][1] for two strings.
 ///
-/// A wrapper for [LCSStr].
+/// A wrapper for [`LCSStr`].
 ///
 ///     use textdistance::nstr::lcsstr;
 ///     assert!(lcsstr("abcdef", "xbcegf") == 2./6.); // "bc"
@@ -107,7 +107,7 @@ pub fn levenshtein(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Ratcliff-Obershelp normalized similarity][1] for two strings.
 ///
-/// A wrapper for [RatcliffObershelp].
+/// A wrapper for [`RatcliffObershelp`].
 ///
 ///     use textdistance::nstr::ratcliff_obershelp;
 ///     assert_eq!(ratcliff_obershelp("abc", "acbd"), 0.5714285714285714);
@@ -119,7 +119,7 @@ pub fn ratcliff_obershelp(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Sift4 distance][1] for two strings using the "simplest" algorithm.
 ///
-/// A wrapper for [Sift4Simple].
+/// A wrapper for [`Sift4Simple`].
 ///
 ///     use textdistance::nstr::sift4_simple;
 ///     assert!(sift4_simple("abc", "acbd") == 2./4.);
@@ -131,7 +131,7 @@ pub fn sift4_simple(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Sift4 distance][1] for two strings using the "common" algorithm.
 ///
-/// A wrapper for [Sift4Common].
+/// A wrapper for [`Sift4Common`].
 ///
 ///     use textdistance::nstr::sift4_common;
 ///     assert!(sift4_common("abc", "acbd") == 2./4.);
@@ -155,7 +155,7 @@ pub fn jaro(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Jaro-Winkler normalized similarity][1] for two strings.
 ///
-/// A wrapper for [JaroWinkler].
+/// A wrapper for [`JaroWinkler`].
 ///
 ///     use textdistance::nstr::jaro_winkler;
 ///     assert_eq!(jaro_winkler("abc", "acbd"), 0.825);
@@ -167,7 +167,7 @@ pub fn jaro_winkler(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Yujian-Bo normalization][1] of [Levenshtein] for two strings.
 ///
-/// A wrapper for [YujianBo].
+/// A wrapper for [`YujianBo`].
 ///
 ///     use textdistance::nstr::yujian_bo;
 ///     assert_eq!(yujian_bo("abc", "acbd"), 0.4444444444444444);
@@ -227,7 +227,7 @@ pub fn jaccard(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Sørensen–Dice normalized similarity][1] for two strings.
 ///
-/// A wrapper for [SorensenDice].
+/// A wrapper for [`SorensenDice`].
 ///
 ///     use textdistance::nstr::sorensen_dice;
 ///     assert_eq!(sorensen_dice("abc", "acbd"), 0.8571428571428571);
@@ -308,7 +308,7 @@ pub fn length(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Smith-Waterman similarity] for two strings.
 ///
-/// A wrapper for [SmithWaterman].
+/// A wrapper for [`SmithWaterman`].
 ///
 ///     use textdistance::nstr::smith_waterman;
 ///     assert!(smith_waterman("abc", "acbd") == 1./4.);
@@ -320,7 +320,7 @@ pub fn smith_waterman(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Entropy]-based [normalized compression distance][1] for two strings.
 ///
-/// A wrapper for [EntropyNCD].
+/// A wrapper for [`EntropyNCD`].
 ///
 ///     use textdistance::nstr::entropy_ncd;
 ///     assert_eq!(entropy_ncd("abc", "acbd"), 0.12174985473119697);

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,6 +1,6 @@
 //! Helper functions providing the default implementation of distance/similarity algorithms for strings.
 //!
-//! See also [textdistance::nstr](super::nstr) for normalized distance.
+//! See also [`textdistance::nstr`](super::nstr) for normalized distance.
 
 use super::Algorithm;
 use super::Bag;
@@ -31,7 +31,7 @@ use super::MLIPNS;
 
 /// Calculate unrestricted [Damerau-Levenshtein distance][1] for two strings.
 ///
-/// A wrapper for [DamerauLevenshtein].
+/// A wrapper for [`DamerauLevenshtein`].
 ///
 ///     use textdistance::str::damerau_levenshtein;
 ///     assert!(damerau_levenshtein("abc", "acbd") == 2); // "bc" swapped and "d" added
@@ -43,7 +43,7 @@ pub fn damerau_levenshtein(s1: &str, s2: &str) -> usize {
 
 /// Calculate restricted [Damerau-Levenshtein distance][1] for two strings.
 ///
-/// A wrapper for [DamerauLevenshtein].
+/// A wrapper for [`DamerauLevenshtein`].
 ///
 ///     use textdistance::str::damerau_levenshtein;
 ///     assert!(damerau_levenshtein("abc", "acbd") == 2); // "bc" swapped and "d" added
@@ -71,7 +71,7 @@ pub fn hamming(s1: &str, s2: &str) -> usize {
 
 /// Calculate the length of the [Longest Common SubSequence][1] for two strings.
 ///
-/// A wrapper for [LCSSeq].
+/// A wrapper for [`LCSSeq`].
 ///
 ///     use textdistance::str::lcsseq;
 ///     assert!(lcsseq("abcdef", "xbcegf") == 4); // "bcef"
@@ -83,7 +83,7 @@ pub fn lcsseq(s1: &str, s2: &str) -> usize {
 
 /// Calculate the length of the [Longest Common SubString][1] for two strings.
 ///
-/// A wrapper for [LCSStr].
+/// A wrapper for [`LCSStr`].
 ///
 ///     use textdistance::str::lcsstr;
 ///     assert!(lcsstr("abcdef", "xbcegf") == 2); // "bc"
@@ -107,7 +107,7 @@ pub fn levenshtein(s1: &str, s2: &str) -> usize {
 
 /// Calculate [Ratcliff-Obershelp normalized similarity][1] for two strings.
 ///
-/// A wrapper for [RatcliffObershelp].
+/// A wrapper for [`RatcliffObershelp`].
 ///
 ///     use textdistance::str::ratcliff_obershelp;
 ///     assert_eq!(ratcliff_obershelp("abc", "acbd"), 0.5714285714285714);
@@ -119,7 +119,7 @@ pub fn ratcliff_obershelp(s1: &str, s2: &str) -> f64 {
 
 /// Calculate [Sift4 distance][1] for two strings using the "simplest" algorithm.
 ///
-/// A wrapper for [Sift4Simple].
+/// A wrapper for [`Sift4Simple`].
 ///
 ///     use textdistance::str::sift4_simple;
 ///     assert!(sift4_simple("abc", "acbd") == 2);
@@ -131,7 +131,7 @@ pub fn sift4_simple(s1: &str, s2: &str) -> usize {
 
 /// Calculate [Sift4 distance][1] for two strings using the "common" algorithm.
 ///
-/// A wrapper for [Sift4Common].
+/// A wrapper for [`Sift4Common`].
 ///
 ///     use textdistance::str::sift4_common;
 ///     assert!(sift4_common("abc", "acbd") == 2);
@@ -155,7 +155,7 @@ pub fn jaro(s1: &str, s2: &str) -> f64 {
 
 /// Calculate [Jaro-Winkler normalized similarity][1] for two strings.
 ///
-/// A wrapper for [JaroWinkler].
+/// A wrapper for [`JaroWinkler`].
 ///
 ///     use textdistance::str::jaro_winkler;
 ///     assert_eq!(jaro_winkler("abc", "acbd"), 0.825);
@@ -167,7 +167,7 @@ pub fn jaro_winkler(s1: &str, s2: &str) -> f64 {
 
 /// Calculate [Yujian-Bo normalization][1] of [Levenshtein] for two strings.
 ///
-/// A wrapper for [YujianBo].
+/// A wrapper for [`YujianBo`].
 ///
 ///     use textdistance::str::yujian_bo;
 ///     assert_eq!(yujian_bo("abc", "acbd"), 0.4444444444444444);
@@ -227,7 +227,7 @@ pub fn jaccard(s1: &str, s2: &str) -> f64 {
 
 /// Calculate [Sørensen–Dice normalized similarity][1] for two strings.
 ///
-/// A wrapper for [SorensenDice].
+/// A wrapper for [`SorensenDice`].
 ///
 ///     use textdistance::str::sorensen_dice;
 ///     assert_eq!(sorensen_dice("abc", "acbd"), 0.8571428571428571);
@@ -308,7 +308,7 @@ pub fn length(s1: &str, s2: &str) -> usize {
 
 /// Calculate [Smith-Waterman similarity] for two strings.
 ///
-/// A wrapper for [SmithWaterman].
+/// A wrapper for [`SmithWaterman`].
 ///
 ///     use textdistance::str::smith_waterman;
 ///     assert!(smith_waterman("abc", "acbd") == 1);
@@ -320,7 +320,7 @@ pub fn smith_waterman(s1: &str, s2: &str) -> usize {
 
 /// Calculate [Entropy]-based [normalized compression distance][1] for two strings.
 ///
-/// A wrapper for [EntropyNCD].
+/// A wrapper for [`EntropyNCD`].
 ///
 ///     use textdistance::str::entropy_ncd;
 ///     assert_eq!(entropy_ncd("abc", "acbd"), 0.12174985473119697);


### PR DESCRIPTION
Addressed some of the clippy lints:
* inline format args
* for loop with inclusive upper bound
* doc strings
* `Default::default` is hard to read, fixed

I tested it with this:

```
cargo clippy --examples --tests --benches --bins --lib -- -W clippy::pedantic
```

P.S.  Please consider renaming default branch to `main`. Thanks!