### PR TITLE
Preparing for primary branch rename

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: main
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Please consider changing primary branch name to `main` (github would do all the needed work, including creating a redirect).

See https://github.com/github/renaming#readme