### PR TITLE
Fix warnings in documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,18 @@ jobs:
           repo-token: ${{ github.token }}
       - run: task check
 
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ github.token }}
+      - run: task pytest
+
   markdownlint-cli:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "textdistance"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "assert2",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "textdistance"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Gram <git@orsinium.dev>"]
 description = "Lots of algorithms to compare how similar two sequences are"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -39,6 +39,8 @@ tasks:
         -- -D clippy::pedantic -D clippy::dbg-macro -D warnings
 
   doc:
+    env:
+      RUSTDOCFLAGS: "-Dwarnings"
     cmds:
       - cargo doc {{.CLI_ARGS}}
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -33,7 +33,10 @@ tasks:
 
   lint:
     cmds:
-      - cargo clippy --examples --tests --benches --bins --lib --workspace -- -D clippy::pedantic -D clippy::dbg-macro -D warnings
+      - >
+        cargo clippy
+        --examples --tests --benches --bins --lib --workspace
+        -- -D clippy::pedantic -D clippy::dbg-macro -D warnings
 
   doc:
     cmds:

--- a/src/algorithms/jaro_winkler.rs
+++ b/src/algorithms/jaro_winkler.rs
@@ -2,7 +2,7 @@
 use super::jaro::Jaro;
 use crate::{Algorithm, Result};
 
-/// [Jaro-Winkler similarity] is a variation of [Jaro] with a better rating for strings with a matching prefix.
+/// [Jaro-Winkler similarity] is a variation of [`Jaro`] with a better rating for strings with a matching prefix.
 ///
 /// The metric is always normalized on the interval from 0.0 to 1.0.
 ///

--- a/src/algorithms/lig3.rs
+++ b/src/algorithms/lig3.rs
@@ -4,7 +4,7 @@ use super::levenshtein::Levenshtein;
 use crate::{Algorithm, Result};
 use std::hash::Hash;
 
-/// [LIG3 similarity] is a normalization of [Hamming] by [Levenshtein].
+/// [LIG3 similarity] is a normalization of [`Hamming`] by [`Levenshtein`].
 ///
 /// [LIG3 similarity]: https://github.com/chrislit/abydos/blob/master/abydos/distance/_lig3.py
 pub struct LIG3 {

--- a/src/algorithms/mlipns.rs
+++ b/src/algorithms/mlipns.rs
@@ -3,7 +3,7 @@ use super::hamming::Hamming;
 use crate::{Algorithm, Result};
 use std::hash::Hash;
 
-/// [MLIPNS similarity] is a normalization for [Hamming] that returns either 0 or 1.
+/// [MLIPNS similarity] is a normalization for [`Hamming`] that returns either 0 or 1.
 ///
 /// MLIPNS stands for Modified Language-Independent Product Name Search.
 ///

--- a/src/algorithms/ratcliff_obershelp.rs
+++ b/src/algorithms/ratcliff_obershelp.rs
@@ -11,7 +11,7 @@ use crate::{Algorithm, Result};
 /// The normalized result is the non-normalized one divided by the sum of the input string lengths.
 ///
 /// [Ratcliff/Obershelp similarity]: https://en.wikipedia.org/wiki/Gestalt_pattern_matching
-/// [LCSStr]: crate::LCSStr
+/// [`LCSStr`]: crate::LCSStr
 #[derive(Default)]
 pub struct RatcliffObershelp {}
 

--- a/src/algorithms/tversky.rs
+++ b/src/algorithms/tversky.rs
@@ -2,11 +2,11 @@
 use crate::counter::Counter;
 use crate::{Algorithm, Result};
 
-/// [Tversky similarity] is a generalization of [`SorensenDice`] and [Jaccard].
+/// [Tversky similarity] is a generalization of [`SorensenDice`] and [`Jaccard`].
 ///
 /// [Tversky similarity]: https://en.wikipedia.org/wiki/Tversky_index
-/// [SorensenDice]: crate::SorensenDice
-/// [Jaccard]: crate::Jaccard
+/// [`SorensenDice`]: crate::SorensenDice
+/// [`Jaccard`]: crate::Jaccard
 pub struct Tversky {
     /// α, the weight of the first sequence (the "prototype").
     pub alpha: f64,

--- a/src/algorithms/yujian_bo.rs
+++ b/src/algorithms/yujian_bo.rs
@@ -2,7 +2,7 @@
 use super::levenshtein::Levenshtein;
 use crate::{Algorithm, Result};
 
-/// [Yujian-Bo distance] is a normalization of [Levenshtein].
+/// [Yujian-Bo distance] is a normalization of [`Levenshtein`].
 ///
 /// [Yujian-Bo distance]: https://ieeexplore.ieee.org/document/4160958
 #[derive(Default)]

--- a/src/nstr.rs
+++ b/src/nstr.rs
@@ -59,7 +59,7 @@ pub fn damerau_levenshtein_restricted(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Hamming distance][1] for two strings.
 ///
-/// A wrapper for [Hamming].
+/// A wrapper for [`Hamming`].
 ///
 ///     use textdistance::nstr::hamming;
 ///     assert!(hamming("abc", "acbd") == 3./4.); // only "a" matches
@@ -95,7 +95,7 @@ pub fn lcsstr(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Levenshtein distance][1] for two strings.
 ///
-/// A wrapper for [Levenshtein].
+/// A wrapper for [`Levenshtein`].
 ///
 ///     use textdistance::nstr::levenshtein;
 ///     assert!(levenshtein("abc", "acbd") == 2./4.); // add "c" at 2 and then swap "c" with "d" at 4
@@ -143,7 +143,7 @@ pub fn sift4_common(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Jaro normalized similarity][1] for two strings.
 ///
-/// A wrapper for [Jaro].
+/// A wrapper for [`Jaro`].
 ///
 ///     use textdistance::nstr::jaro;
 ///     assert_eq!(jaro("abc", "acbd"), 0.8055555555555555);
@@ -179,7 +179,7 @@ pub fn yujian_bo(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [MLIPNS normalization][1] of [Hamming] for two strings.
 ///
-/// A wrapper for [MLIPNS].
+/// A wrapper for [`MLIPNS`].
 ///
 ///     use textdistance::nstr::mlipns;
 ///     assert!(mlipns("abc", "acbd") == 0.);
@@ -191,7 +191,7 @@ pub fn mlipns(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Bag distance][1] for two strings.
 ///
-/// A wrapper for [Bag].
+/// A wrapper for [`Bag`].
 ///
 ///     use textdistance::nstr::bag;
 ///     assert!(bag("abc", "acbd") == 1./4.);
@@ -203,7 +203,7 @@ pub fn bag(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [LIG3 normalization][1] of [Hamming] by [Levenshtein] for two strings.
 ///
-/// A wrapper for [LIG3].
+/// A wrapper for [`LIG3`].
 ///
 ///     use textdistance::nstr::lig3;
 ///     assert_eq!(lig3("abc", "acbd"), 0.5);
@@ -215,7 +215,7 @@ pub fn lig3(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Jaccard normalized similarity][1] for two strings.
 ///
-/// A wrapper for [Jaccard].
+/// A wrapper for [`Jaccard`].
 ///
 ///     use textdistance::nstr::jaccard;
 ///     assert_eq!(jaccard("abc", "acbd"), 0.75);
@@ -239,7 +239,7 @@ pub fn sorensen_dice(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Tversky normalized similarity][1] for two strings.
 ///
-/// A wrapper for [Tversky].
+/// A wrapper for [`Tversky`].
 ///
 ///     use textdistance::nstr::tversky;
 ///     assert_eq!(tversky("abc", "acbd"), 0.75);
@@ -251,7 +251,7 @@ pub fn tversky(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Overlap normalized similarity][1] for two strings.
 ///
-/// A wrapper for [Overlap].
+/// A wrapper for [`Overlap`].
 ///
 ///     use textdistance::nstr::overlap;
 ///     assert_eq!(overlap("abc", "acbd"), 1.0);
@@ -263,7 +263,7 @@ pub fn overlap(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Cosine normalized similarity][1] for two strings.
 ///
-/// A wrapper for [Cosine].
+/// A wrapper for [`Cosine`].
 ///
 ///     use textdistance::nstr::cosine;
 ///     assert_eq!(cosine("abc", "acbd"), 0.8660254037844387);
@@ -275,7 +275,7 @@ pub fn cosine(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized common prefix length for two strings.
 ///
-/// A wrapper for [Prefix].
+/// A wrapper for [`Prefix`].
 ///
 ///     use textdistance::nstr::prefix;
 ///     assert!(prefix("abc", "acbd") == 1./4.); // "a"
@@ -286,7 +286,7 @@ pub fn prefix(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized common suffix length for two strings.
 ///
-/// A wrapper for [Suffix].
+/// A wrapper for [`Suffix`].
 ///
 ///     use textdistance::nstr::suffix;
 ///     assert!(suffix("abcd", "axcd") == 2./4.); // "cd"
@@ -297,7 +297,7 @@ pub fn suffix(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized length distance for two strings.
 ///
-/// A wrapper for [Length].
+/// A wrapper for [`Length`].
 ///
 ///     use textdistance::nstr::length;
 ///     assert!(length("abcd", "axc") == (4. - 3.) / 4.);
@@ -333,7 +333,7 @@ pub fn entropy_ncd(s1: &str, s2: &str) -> f64 {
 
 /// Calculate normalized [Roberts similarity] for two strings.
 ///
-/// A wrapper for [Roberts].
+/// A wrapper for [`Roberts`].
 ///
 ///     use textdistance::nstr::roberts;
 ///     assert_eq!(roberts("abc", "acbd"), 0.8571428571428571);

--- a/src/str.rs
+++ b/src/str.rs
@@ -59,7 +59,7 @@ pub fn damerau_levenshtein_restricted(s1: &str, s2: &str) -> usize {
 
 /// Calculate [Hamming distance][1] for two strings.
 ///
-/// A wrapper for [Hamming].
+/// A wrapper for [`Hamming`].
 ///
 ///     use textdistance::str::hamming;
 ///     assert!(hamming("abc", "acbd") == 3); // only "a" matches
@@ -95,7 +95,7 @@ pub fn lcsstr(s1: &str, s2: &str) -> usize {
 
 /// Calculate [Levenshtein distance][1] for two strings.
 ///
-/// A wrapper for [Levenshtein].
+/// A wrapper for [`Levenshtein`].
 ///
 ///     use textdistance::str::levenshtein;
 ///     assert!(levenshtein("abc", "acbd") == 2); // add "c" at 2 and then swap "c" with "d" at 4
@@ -143,7 +143,7 @@ pub fn sift4_common(s1: &str, s2: &str) -> usize {
 
 /// Calculate [Jaro normalized similarity][1] for two strings.
 ///
-/// A wrapper for [Jaro].
+/// A wrapper for [`Jaro`].
 ///
 ///     use textdistance::str::jaro;
 ///     assert_eq!(jaro("abc", "acbd"), 0.8055555555555555);
@@ -179,7 +179,7 @@ pub fn yujian_bo(s1: &str, s2: &str) -> f64 {
 
 /// Calculate [MLIPNS normalization][1] of [Hamming] for two strings.
 ///
-/// A wrapper for [MLIPNS].
+/// A wrapper for [`MLIPNS`].
 ///
 ///     use textdistance::str::mlipns;
 ///     assert!(mlipns("abc", "acbd") == 0);
@@ -191,7 +191,7 @@ pub fn mlipns(s1: &str, s2: &str) -> usize {
 
 /// Calculate [Bag distance][1] for two strings.
 ///
-/// A wrapper for [Bag].
+/// A wrapper for [`Bag`].
 ///
 ///     use textdistance::str::bag;
 ///     assert!(bag("abc", "acbd") == 1);
@@ -203,7 +203,7 @@ pub fn bag(s1: &str, s2: &str) -> usize {
 
 /// Calculate [LIG3 normalization][1] of [Hamming] by [Levenshtein] for two strings.
 ///
-/// A wrapper for [LIG3].
+/// A wrapper for [`LIG3`].
 ///
 ///     use textdistance::str::lig3;
 ///     assert_eq!(lig3("abc", "acbd"), 0.5);
@@ -215,7 +215,7 @@ pub fn lig3(s1: &str, s2: &str) -> f64 {
 
 /// Calculate [Jaccard normalized similarity][1] for two strings.
 ///
-/// A wrapper for [Jaccard].
+/// A wrapper for [`Jaccard`].
 ///
 ///     use textdistance::str::jaccard;
 ///     assert_eq!(jaccard("abc", "acbd"), 0.75);
@@ -239,7 +239,7 @@ pub fn sorensen_dice(s1: &str, s2: &str) -> f64 {
 
 /// Calculate [Tversky normalized similarity][1] for two strings.
 ///
-/// A wrapper for [Tversky].
+/// A wrapper for [`Tversky`].
 ///
 ///     use textdistance::str::tversky;
 ///     assert_eq!(tversky("abc", "acbd"), 0.75);
@@ -251,7 +251,7 @@ pub fn tversky(s1: &str, s2: &str) -> f64 {
 
 /// Calculate [Overlap normalized similarity][1] for two strings.
 ///
-/// A wrapper for [Overlap].
+/// A wrapper for [`Overlap`].
 ///
 ///     use textdistance::str::overlap;
 ///     assert_eq!(overlap("abc", "acbd"), 1.0);
@@ -263,7 +263,7 @@ pub fn overlap(s1: &str, s2: &str) -> f64 {
 
 /// Calculate [Cosine normalized similarity][1] for two strings.
 ///
-/// A wrapper for [Cosine].
+/// A wrapper for [`Cosine`].
 ///
 ///     use textdistance::str::cosine;
 ///     assert_eq!(cosine("abc", "acbd"), 0.8660254037844387);
@@ -275,7 +275,7 @@ pub fn cosine(s1: &str, s2: &str) -> f64 {
 
 /// Calculate common prefix length for two strings.
 ///
-/// A wrapper for [Prefix].
+/// A wrapper for [`Prefix`].
 ///
 ///     use textdistance::str::prefix;
 ///     assert!(prefix("abc", "acbd") == 1); // "a"
@@ -286,7 +286,7 @@ pub fn prefix(s1: &str, s2: &str) -> usize {
 
 /// Calculate common suffix length for two strings.
 ///
-/// A wrapper for [Suffix].
+/// A wrapper for [`Suffix`].
 ///
 ///     use textdistance::str::suffix;
 ///     assert!(suffix("abcd", "axcd") == 2); // "cd"
@@ -297,7 +297,7 @@ pub fn suffix(s1: &str, s2: &str) -> usize {
 
 /// Calculate length distance for two strings.
 ///
-/// A wrapper for [Length].
+/// A wrapper for [`Length`].
 ///
 ///     use textdistance::str::length;
 ///     assert!(length("abcd", "axc") == 4 - 3);
@@ -333,7 +333,7 @@ pub fn entropy_ncd(s1: &str, s2: &str) -> f64 {
 
 /// Calculate [Roberts similarity] for two strings.
 ///
-/// A wrapper for [Roberts].
+/// A wrapper for [`Roberts`].
 ///
 ///     use textdistance::str::roberts;
 ///     assert_eq!(roberts("abc", "acbd"), 0.8571428571428571);

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -39,7 +39,7 @@ def test_str_shortcut_exists(alg: str) -> None:
     assert f'fn {alg}(' in text
     alg = alg.replace('_', '')
     assert f'{alg}::default().for_str(s1, s2).' in text.lower()
-    assert f'/// a wrapper for [{alg}].\n' in text.lower()
+    assert f'/// a wrapper for [`{alg}`].\n' in text.lower()
 
 
 def test_str_docs_consistency() -> None:
@@ -55,7 +55,7 @@ def test_nstr_shortcut_exists(alg: str) -> None:
     assert f'fn {alg}(' in text
     alg = alg.replace('_', '')
     assert f'{alg}::default().for_str(s1, s2).nval()' in text.lower()
-    assert f'/// a wrapper for [{alg}].\n' in text.lower()
+    assert f'/// a wrapper for [`{alg}`].\n' in text.lower()
 
 
 def test_nstr_docs_consistency() -> None:


### PR DESCRIPTION
The #3 PR introduced a few warnings in `cargo doc` that slipped past CI. This PR addresses the issues:

1. Run pytest introspection tests on CI.
2. Fail `cargo doc` on warnings.
3. Actualize introspection tests to always require backticks when referring to an algorithm.
4. Add missed backticks.