### PR TITLE
no_std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "textdistance"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "assert2",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,49 +3,55 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "assert2"
-version = "0.3.10"
+name = "anstyle"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f101feec0a9ef4ef850105353c3726da5db058e19b8c53a6ab1fc4b7f7e33"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "assert2"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d31fea2b6e18dfe892863c3a0a68f9e005b0195565f3d55b8612946ebca789cc"
 dependencies = [
  "assert2-macros",
+ "diff",
  "is-terminal",
  "yansi",
 ]
 
 [[package]]
 name = "assert2-macros"
-version = "0.3.9"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fabe93976c52f6ab5c8c356335953880c1030093b067500b13bd33ec0ea6377"
+checksum = "3c1ac052c642f6d94e4be0b33028b346b7ab809ea5432b584eb8859f12f7ad2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bit-set"
@@ -64,33 +70,27 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
-name = "cc"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -100,9 +100,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -111,15 +111,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -127,40 +127,44 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.24"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef2b3ded6a26dfaec672a742c93c8cf6b689220324da509ec5caa20de55dc83"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
- "bitflags",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+dependencies = [
+ "anstyle",
  "clap_lex",
- "indexmap",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
  "anes",
- "atty",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
@@ -183,83 +187,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
-dependencies = [
- "cfg-if",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fnv"
@@ -269,9 +259,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -284,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -294,15 +284,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -311,44 +301,44 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -364,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -374,81 +364,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "1.8.2"
+name = "glob"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
- "windows-sys 0.48.0",
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -462,110 +423,82 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memoffset"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
-dependencies = [
- "autocfg",
-]
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi 0.2.6",
- "libc",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -575,9 +508,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -588,50 +521,61 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
+ "bit-vec",
  "bitflags",
- "byteorder",
  "lazy_static",
  "num-traits",
- "quick-error 2.0.1",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.6.29",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -644,16 +588,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -699,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -709,51 +647,54 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
- "regex-syntax 0.7.1",
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
-name = "regex-syntax"
-version = "0.7.1"
+name = "relative-path"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.17.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+checksum = "7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936"
 dependencies = [
  "futures",
  "futures-timer",
@@ -763,39 +704,42 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.17.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+checksum = "c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42"
 dependencies = [
  "cfg-if",
+ "glob",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
+ "regex",
+ "relative-path",
  "rustc_version",
- "syn 1.0.109",
+ "syn",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -805,16 +749,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -826,73 +770,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -901,15 +829,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "once_cell",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -924,12 +852,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +862,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,15 +886,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "wait-timeout"
@@ -968,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -984,34 +923,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1019,198 +959,156 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
+name = "windows_i686_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
+name = "winnow"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "textdistance"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 authors = ["Gram <git@orsinium.dev>"]
 description = "Lots of algorithms to compare how similar two sequences are"
@@ -10,6 +10,7 @@ keywords = ["jaro", "hamming", "levenshtein", "similarity", "distance"]
 categories = [
     "algorithms",
     "science",
+    "no-std",
     "text-processing",
     "command-line-interface",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,19 +6,17 @@ authors = ["Gram <git@orsinium.dev>"]
 description = "Lots of algorithms to compare how similar two sequences are"
 repository = "https://github.com/life4/textdistance.rs"
 license = "MIT"
-keywords = [
-    "jaro",
-    "hamming",
-    "levenshtein",
-    "similarity",
-    "distance",
-]
+keywords = ["jaro", "hamming", "levenshtein", "similarity", "distance"]
 categories = [
     "algorithms",
     "science",
     "text-processing",
     "command-line-interface",
 ]
+
+[features]
+default = ["std"]
+std = []
 
 [dev-dependencies]
 assert2 = "0.3.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ default = ["std"]
 std = []
 
 [dev-dependencies]
-assert2 = "0.3.10"
-criterion = "0.4.0"
+assert2 = "0.3.15"
+criterion = "0.5.1"
 proptest = "1.1.0"
-rstest = "0.17.0"
+rstest = "0.22.0"
 unicode-segmentation = "1.10.1"
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features:
 + 📚 Contains 20+ algorithms for all purposes.
 + 🔬 Includes state-of-the-art algorithms like `EntropyNCD` and `Sift4`.
 + 🪶 Zero-dependency.
++ 🐜 `#![no_std]` support (embedded systems).
 + 🔨 Works with any iterators, including bytes, code points, Unicode grapheme clusters, words, and numbers.
 + ❤️ Friendly and consistent API for all algorithms.
 + 📏 Optional normalization of the result on the 0.0-1.0 interval.
@@ -64,6 +65,12 @@ Normalization for other metrics:
 
 ```shell
 cargo add textdistance
+```
+
+Or if you're going to use it in a [no_std](https://docs.rust-embedded.org/book/intro/no-std.html) project:
+
+```shell
+cargo add --no-default-features textdistance
 ```
 
 ## Usage

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -57,6 +57,7 @@ tasks:
       CLICOLOR_FORCE: "yes"
     cmds:
       - cargo nextest run --no-fail-fast {{.CLI_ARGS}}
+      - cargo build --no-default-features
 
   doctest:
     cmds:

--- a/benches/str_benchmarks.rs
+++ b/benches/str_benchmarks.rs
@@ -1,7 +1,7 @@
-use core::fs;
 use core::time::Duration;
 use criterion::BenchmarkId;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::fs;
 use textdistance::{nstr, str};
 
 fn read_licenses() -> Vec<(String, String)> {

--- a/benches/str_benchmarks.rs
+++ b/benches/str_benchmarks.rs
@@ -1,7 +1,7 @@
+use core::fs;
+use core::time::Duration;
 use criterion::BenchmarkId;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use std::fs;
-use std::time::Duration;
 use textdistance::{nstr, str};
 
 fn read_licenses() -> Vec<(String, String)> {

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -1,5 +1,6 @@
 use super::Result;
-use std::hash::Hash;
+use alloc::vec::Vec;
+use core::hash::Hash;
 
 /// A base trait for all distance/similarity algorithms.
 ///

--- a/src/algorithms/bag.rs
+++ b/src/algorithms/bag.rs
@@ -13,7 +13,7 @@ impl Algorithm<usize> for Bag {
     fn for_iter<C, E>(&self, s1: C, s2: C) -> Result<usize>
     where
         C: Iterator<Item = E>,
-        E: Eq + std::hash::Hash,
+        E: Eq + core::hash::Hash,
     {
         let c1 = Counter::from_iter(s1);
         let c2 = Counter::from_iter(s2);

--- a/src/algorithms/bag.rs
+++ b/src/algorithms/bag.rs
@@ -1,5 +1,5 @@
 //! Bag distance
-
+#![cfg(feature = "std")]
 use crate::counter::Counter;
 use crate::{Algorithm, Result};
 

--- a/src/algorithms/cosine.rs
+++ b/src/algorithms/cosine.rs
@@ -15,7 +15,7 @@ impl Algorithm<f64> for Cosine {
     fn for_iter<C, E>(&self, s1: C, s2: C) -> Result<f64>
     where
         C: Iterator<Item = E>,
-        E: Eq + std::hash::Hash,
+        E: Eq + core::hash::Hash,
     {
         let c1 = Counter::from_iter(s1);
         let c2 = Counter::from_iter(s2);

--- a/src/algorithms/cosine.rs
+++ b/src/algorithms/cosine.rs
@@ -1,4 +1,5 @@
 //! Cosine similarity
+#![cfg(feature = "std")]
 use crate::counter::Counter;
 use crate::{Algorithm, Result};
 

--- a/src/algorithms/damerau_levenshtein.rs
+++ b/src/algorithms/damerau_levenshtein.rs
@@ -1,7 +1,9 @@
 //! Damerau-Levenshtein distance
 use crate::{Algorithm, Result};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::hash::Hash;
 use std::collections::HashMap;
-use std::hash::Hash;
 
 /// [Damerau-Levenshtein distance] is an edit distance between two sequences.
 ///

--- a/src/algorithms/damerau_levenshtein.rs
+++ b/src/algorithms/damerau_levenshtein.rs
@@ -1,4 +1,5 @@
 //! Damerau-Levenshtein distance
+#![cfg(feature = "std")]
 use crate::{Algorithm, Result};
 use alloc::vec;
 use alloc::vec::Vec;

--- a/src/algorithms/entropy_ncd.rs
+++ b/src/algorithms/entropy_ncd.rs
@@ -1,7 +1,7 @@
 //! Entropy-based Normalized Compression Distance
 use crate::counter::Counter;
 use crate::{Algorithm, Result};
-use std::hash::Hash;
+use core::hash::Hash;
 
 /// Entropy-based [Normalized Compression Distance].
 ///
@@ -46,7 +46,7 @@ impl Algorithm<f64> for EntropyNCD {
     fn for_iter<C, E>(&self, s1: C, s2: C) -> Result<f64>
     where
         C: Iterator<Item = E>,
-        E: Eq + std::hash::Hash,
+        E: Eq + core::hash::Hash,
     {
         let c1 = Counter::from_iter(s1);
         let c2 = Counter::from_iter(s2);

--- a/src/algorithms/entropy_ncd.rs
+++ b/src/algorithms/entropy_ncd.rs
@@ -1,4 +1,5 @@
 //! Entropy-based Normalized Compression Distance
+#![cfg(feature = "std")]
 use crate::counter::Counter;
 use crate::{Algorithm, Result};
 use core::hash::Hash;

--- a/src/algorithms/jaccard.rs
+++ b/src/algorithms/jaccard.rs
@@ -1,4 +1,5 @@
 //! Jaccard index
+#![cfg(feature = "std")]
 use crate::counter::Counter;
 use crate::{Algorithm, Result};
 

--- a/src/algorithms/jaccard.rs
+++ b/src/algorithms/jaccard.rs
@@ -17,7 +17,7 @@ impl Algorithm<f64> for Jaccard {
     fn for_iter<C, E>(&self, s1: C, s2: C) -> Result<f64>
     where
         C: Iterator<Item = E>,
-        E: Eq + std::hash::Hash,
+        E: Eq + core::hash::Hash,
     {
         let c1 = Counter::from_iter(s1);
         let c2 = Counter::from_iter(s2);

--- a/src/algorithms/jaro.rs
+++ b/src/algorithms/jaro.rs
@@ -1,5 +1,6 @@
 //! Jaro similarity
 use crate::{Algorithm, Result};
+use alloc::vec;
 
 /// [Jaro similarity] is calculated based on the number of transpositions to turn one string into the other.
 ///

--- a/src/algorithms/jaro_winkler.rs
+++ b/src/algorithms/jaro_winkler.rs
@@ -34,7 +34,7 @@ impl JaroWinkler {
     fn winklerize<C, E>(&self, jaro: f64, s1: C, s2: C) -> f64
     where
         C: Iterator<Item = E>,
-        E: Eq + std::hash::Hash,
+        E: Eq + core::hash::Hash,
     {
         debug_assert!(self.prefix_weight * self.max_prefix as f64 <= 1.0);
         let mut prefix_len = 0;
@@ -55,7 +55,7 @@ impl JaroWinkler {
 impl Algorithm<f64> for JaroWinkler {
     fn for_vec<E>(&self, s1: &[E], s2: &[E]) -> Result<f64>
     where
-        E: Eq + std::hash::Hash,
+        E: Eq + core::hash::Hash,
     {
         let jaro = self.jaro.for_vec(s1, s2).nval();
         Result {

--- a/src/algorithms/lcsseq.rs
+++ b/src/algorithms/lcsseq.rs
@@ -1,5 +1,7 @@
 //! Longest common subsequence
 use crate::{Algorithm, Result};
+use alloc::vec;
+use alloc::vec::Vec;
 
 /// The length of the [Longest common subsequence].
 ///

--- a/src/algorithms/lcsstr.rs
+++ b/src/algorithms/lcsstr.rs
@@ -1,5 +1,6 @@
 //! Longest common substring
 use crate::{Algorithm, Result};
+use alloc::vec;
 
 /// The length of the [Longest common substring].
 ///

--- a/src/algorithms/levenshtein.rs
+++ b/src/algorithms/levenshtein.rs
@@ -1,5 +1,6 @@
 //! Levenshtein distance
 use crate::{Algorithm, Result};
+use alloc::vec::Vec;
 
 /// [Levenshtein distance] is an edit distance between two sequences.
 ///

--- a/src/algorithms/lig3.rs
+++ b/src/algorithms/lig3.rs
@@ -2,7 +2,7 @@
 use super::hamming::Hamming;
 use super::levenshtein::Levenshtein;
 use crate::{Algorithm, Result};
-use std::hash::Hash;
+use core::hash::Hash;
 
 /// [LIG3 similarity] is a normalization of [`Hamming`] by [`Levenshtein`].
 ///

--- a/src/algorithms/mlipns.rs
+++ b/src/algorithms/mlipns.rs
@@ -1,7 +1,7 @@
 //! MLIPNS similarity
 use super::hamming::Hamming;
 use crate::{Algorithm, Result};
-use std::hash::Hash;
+use core::hash::Hash;
 
 /// [MLIPNS similarity] is a normalization for [`Hamming`] that returns either 0 or 1.
 ///

--- a/src/algorithms/overlap.rs
+++ b/src/algorithms/overlap.rs
@@ -12,7 +12,7 @@ impl Algorithm<f64> for Overlap {
     fn for_iter<C, E>(&self, s1: C, s2: C) -> Result<f64>
     where
         C: Iterator<Item = E>,
-        E: Eq + std::hash::Hash,
+        E: Eq + core::hash::Hash,
     {
         let c1 = Counter::from_iter(s1);
         let c2 = Counter::from_iter(s2);

--- a/src/algorithms/overlap.rs
+++ b/src/algorithms/overlap.rs
@@ -1,4 +1,5 @@
 //! Overlap coefficient
+#![cfg(feature = "std")]
 use crate::counter::Counter;
 use crate::{Algorithm, Result};
 

--- a/src/algorithms/ratcliff_obershelp.rs
+++ b/src/algorithms/ratcliff_obershelp.rs
@@ -1,5 +1,7 @@
 //! Gestalt pattern matching
 use crate::{Algorithm, Result};
+use alloc::vec;
+use alloc::vec::Vec;
 
 /// [Ratcliff/Obershelp similarity] is [`LCSStr`] that recursively finds matches
 /// on both sides of the longest substring.

--- a/src/algorithms/ratcliff_obershelp.rs
+++ b/src/algorithms/ratcliff_obershelp.rs
@@ -23,8 +23,7 @@ impl Algorithm<usize> for RatcliffObershelp {
         stack.push(((0, l1), (0, l2)));
         let mut result = 0;
 
-        while !stack.is_empty() {
-            let top = stack.pop().unwrap();
+        while let Some(top) = stack.pop() {
             let ((part1_start, part1_len), (part2_start, part2_len)) = top;
             let s1_part = s1[part1_start..(part1_start + part1_len)].iter();
             let s2_part: Vec<&E> = s2[part2_start..(part2_start + part2_len)].iter().collect();

--- a/src/algorithms/roberts.rs
+++ b/src/algorithms/roberts.rs
@@ -1,4 +1,5 @@
 //! Roberts similarity
+#![cfg(feature = "std")]
 use crate::counter::Counter;
 use crate::{Algorithm, Result};
 

--- a/src/algorithms/roberts.rs
+++ b/src/algorithms/roberts.rs
@@ -14,7 +14,7 @@ impl Algorithm<f64> for Roberts {
     fn for_iter<C, E>(&self, s1: C, s2: C) -> Result<f64>
     where
         C: Iterator<Item = E>,
-        E: Eq + std::hash::Hash,
+        E: Eq + core::hash::Hash,
     {
         let c1 = Counter::from_iter(s1);
         let c2 = Counter::from_iter(s2);

--- a/src/algorithms/sift4_common.rs
+++ b/src/algorithms/sift4_common.rs
@@ -1,5 +1,6 @@
 //! Sift4 distance
 use crate::{Algorithm, Result};
+use alloc::vec::Vec;
 
 /// [Sift4 distance] is an edit algorithm designed to be "fast and relatively accurate".
 ///
@@ -44,7 +45,7 @@ impl Algorithm<usize> for Sift4Common {
         let mut lcss = 0; // largest common subsequence
         let mut local_cs = 0; // local common substring
         let mut trans = 0; // number of transpositions ('ab' vs 'ba')
-        let mut offset_arr: Vec<Offset> = vec![]; // offset pair array, for computing the transpositions
+        let mut offset_arr: Vec<Offset> = Vec::new(); // offset pair array, for computing the transpositions
         while (c1 < l1) && (c2 < l2) {
             if s1[c1] == s2[c2] {
                 local_cs += 1;

--- a/src/algorithms/smith_waterman.rs
+++ b/src/algorithms/smith_waterman.rs
@@ -1,5 +1,7 @@
 //! Smith-Waterman sequence alignment
 use crate::{Algorithm, Result};
+use alloc::vec;
+use alloc::vec::Vec;
 
 /// [Smith-Waterman similarity] is edit-based and designed for nucleic acid (and protein) sequences.
 ///

--- a/src/algorithms/sorensen_dice.rs
+++ b/src/algorithms/sorensen_dice.rs
@@ -1,4 +1,5 @@
 //! Sørensen-Dice coefficient
+#![cfg(feature = "std")]
 use crate::counter::Counter;
 use crate::{Algorithm, Result};
 

--- a/src/algorithms/sorensen_dice.rs
+++ b/src/algorithms/sorensen_dice.rs
@@ -12,7 +12,7 @@ impl Algorithm<f64> for SorensenDice {
     fn for_iter<C, E>(&self, s1: C, s2: C) -> Result<f64>
     where
         C: Iterator<Item = E>,
-        E: Eq + std::hash::Hash,
+        E: Eq + core::hash::Hash,
     {
         let c1 = Counter::from_iter(s1);
         let c2 = Counter::from_iter(s2);

--- a/src/algorithms/tversky.rs
+++ b/src/algorithms/tversky.rs
@@ -1,4 +1,5 @@
 //! Tversky index
+#![cfg(feature = "std")]
 use crate::counter::Counter;
 use crate::{Algorithm, Result};
 

--- a/src/algorithms/tversky.rs
+++ b/src/algorithms/tversky.rs
@@ -30,7 +30,7 @@ impl Algorithm<f64> for Tversky {
     fn for_iter<C, E>(&self, s1: C, s2: C) -> Result<f64>
     where
         C: Iterator<Item = E>,
-        E: Eq + std::hash::Hash,
+        E: Eq + core::hash::Hash,
     {
         let c1 = Counter::from_iter(s1);
         let c2 = Counter::from_iter(s2);

--- a/src/algorithms/yujian_bo.rs
+++ b/src/algorithms/yujian_bo.rs
@@ -15,7 +15,7 @@ impl Algorithm<f64> for YujianBo {
     fn for_iter<C, E>(&self, s1: C, s2: C) -> Result<f64>
     where
         C: Iterator<Item = E>,
-        E: Eq + std::hash::Hash,
+        E: Eq + core::hash::Hash,
     {
         let lev = self.levenshtein.for_iter(s1, s2);
         let dc: usize = self.levenshtein.del_cost;

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -66,7 +66,7 @@ where
             result.insert(key, *lhs_count + rhs_count);
         }
         for (key, rhs_count) in &rhs.map {
-            if self.map.get(key).is_none() {
+            if !self.map.contains_key(key) {
                 result.insert(key, *rhs_count);
             }
         }
@@ -92,7 +92,7 @@ where
             result += lhs_count.max(rhs_count);
         }
         for (key, rhs_count) in &rhs.map {
-            if self.map.get(key).is_none() {
+            if !self.map.contains_key(key) {
                 result += rhs_count;
             }
         }

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,5 +1,5 @@
+use core::hash::Hash;
 use std::collections::HashMap;
-use std::hash::Hash;
 
 /// Multiset container inspired by Python's `collections.Counter`.
 pub struct Counter<K> {

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 use core::hash::Hash;
 use std::collections::HashMap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 #![deny(clippy::all, clippy::pedantic)]
@@ -5,7 +6,8 @@
     clippy::cast_precision_loss,
     clippy::must_use_candidate,
     clippy::similar_names,
-    clippy::unreadable_literal
+    clippy::unreadable_literal,
+    clippy::wildcard_imports
 )]
 
 extern crate alloc;
@@ -46,11 +48,16 @@ mod algorithms {
 }
 
 pub use self::algorithm::Algorithm;
+#[cfg(feature = "std")]
 pub use self::algorithms::bag::Bag;
+#[cfg(feature = "std")]
 pub use self::algorithms::cosine::Cosine;
+#[cfg(feature = "std")]
 pub use self::algorithms::damerau_levenshtein::DamerauLevenshtein;
+#[cfg(feature = "std")]
 pub use self::algorithms::entropy_ncd::EntropyNCD;
 pub use self::algorithms::hamming::Hamming;
+#[cfg(feature = "std")]
 pub use self::algorithms::jaccard::Jaccard;
 pub use self::algorithms::jaro::Jaro;
 pub use self::algorithms::jaro_winkler::JaroWinkler;
@@ -60,15 +67,19 @@ pub use self::algorithms::length::Length;
 pub use self::algorithms::levenshtein::Levenshtein;
 pub use self::algorithms::lig3::LIG3;
 pub use self::algorithms::mlipns::MLIPNS;
+#[cfg(feature = "std")]
 pub use self::algorithms::overlap::Overlap;
 pub use self::algorithms::prefix::Prefix;
 pub use self::algorithms::ratcliff_obershelp::RatcliffObershelp;
+#[cfg(feature = "std")]
 pub use self::algorithms::roberts::Roberts;
 pub use self::algorithms::sift4_common::Sift4Common;
 pub use self::algorithms::sift4_simple::Sift4Simple;
 pub use self::algorithms::smith_waterman::SmithWaterman;
+#[cfg(feature = "std")]
 pub use self::algorithms::sorensen_dice::SorensenDice;
 pub use self::algorithms::suffix::Suffix;
+#[cfg(feature = "std")]
 pub use self::algorithms::tversky::Tversky;
 pub use self::algorithms::yujian_bo::YujianBo;
 pub use self::result::Result;
@@ -91,6 +102,7 @@ mod tests {
             3 => LCSStr::default().for_str(s1, s2),
             4 => RatcliffObershelp::default().for_str(s1, s2),
             5 => Levenshtein::default().for_str(s1, s2),
+            #[cfg(feature = "std")]
             6 => DamerauLevenshtein::default().for_str(s1, s2),
             7 => Sift4Simple::default().for_str(s1, s2),
             8 => MLIPNS::default().for_str(s1, s2),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
     clippy::must_use_candidate,
     clippy::similar_names,
     clippy::unreadable_literal,
+    clippy::doc_markdown,
     clippy::wildcard_imports
 )]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
-#![warn(clippy::all, clippy::pedantic)]
+#![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::cast_precision_loss,
     clippy::must_use_candidate,
     clippy::similar_names,
     clippy::unreadable_literal
 )]
+
+extern crate alloc;
 
 mod algorithm;
 mod counter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::cast_precision_loss)]
 
-use std::borrow::Borrow;
+use core::borrow::Borrow;
 use textdistance::str;
 
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
+    let args: Vec<String> = core::env::args().collect();
     let alg_name = args.get(1).expect("algorithm name is required");
     let s1 = args.get(2).expect("first text is required");
     let s2 = args.get(3).expect("second text is required");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,4 @@
-#![allow(clippy::cast_precision_loss)]
-
 use core::borrow::Borrow;
-use textdistance::str;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -9,9 +6,46 @@ fn main() {
     let s1 = args.get(2).expect("first text is required");
     let s2 = args.get(3).expect("second text is required");
 
+    #[allow(clippy::cast_precision_loss)]
     let res: f64 = match alg_name.to_lowercase().borrow() {
-        "hamming" => str::hamming(s1, s2) as f64,
-        "roberts" => str::roberts(s1, s2),
+        #[cfg(feature = "std")]
+        "damerau_levenshtein" => textdistance::str::damerau_levenshtein(s1, s2) as f64,
+        #[cfg(feature = "std")]
+        "damerau_levenshtein_restricted" => {
+            textdistance::str::damerau_levenshtein_restricted(s1, s2) as f64
+        }
+        "hamming" => textdistance::str::hamming(s1, s2) as f64,
+        "lcsseq" => textdistance::str::lcsseq(s1, s2) as f64,
+        "lcsstr" => textdistance::str::lcsstr(s1, s2) as f64,
+        "levenshtein" => textdistance::str::levenshtein(s1, s2) as f64,
+        "ratcliff_obershelp" => textdistance::str::ratcliff_obershelp(s1, s2),
+        "sift4_simple" => textdistance::str::sift4_simple(s1, s2) as f64,
+        "sift4_common" => textdistance::str::sift4_common(s1, s2) as f64,
+        "jaro" => textdistance::str::jaro(s1, s2),
+        "jaro_winkler" => textdistance::str::jaro_winkler(s1, s2),
+        "yujian_bo" => textdistance::str::yujian_bo(s1, s2),
+        "mlipns" => textdistance::str::mlipns(s1, s2) as f64,
+        #[cfg(feature = "std")]
+        "bag" => textdistance::str::bag(s1, s2) as f64,
+        "lig3" => textdistance::str::lig3(s1, s2),
+        #[cfg(feature = "std")]
+        "jaccard" => textdistance::str::jaccard(s1, s2),
+        #[cfg(feature = "std")]
+        "sorensen_dice" => textdistance::str::sorensen_dice(s1, s2),
+        #[cfg(feature = "std")]
+        "tversky" => textdistance::str::tversky(s1, s2),
+        #[cfg(feature = "std")]
+        "overlap" => textdistance::str::overlap(s1, s2),
+        #[cfg(feature = "std")]
+        "cosine" => textdistance::str::cosine(s1, s2),
+        "prefix" => textdistance::str::prefix(s1, s2) as f64,
+        "suffix" => textdistance::str::suffix(s1, s2) as f64,
+        "length" => textdistance::str::length(s1, s2) as f64,
+        "smith_waterman" => textdistance::str::smith_waterman(s1, s2) as f64,
+        #[cfg(feature = "std")]
+        "entropy_ncd" => textdistance::str::entropy_ncd(s1, s2) as f64,
+        #[cfg(feature = "std")]
+        "roberts" => textdistance::str::roberts(s1, s2),
         _ => panic!("unknown algorithm name"),
     };
     println!("{res}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use core::borrow::Borrow;
 use textdistance::str;
 
 fn main() {
-    let args: Vec<String> = core::env::args().collect();
+    let args: Vec<String> = std::env::args().collect();
     let alg_name = args.get(1).expect("algorithm name is required");
     let s1 = args.get(2).expect("first text is required");
     let s2 = args.get(3).expect("second text is required");

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
         "length" => textdistance::str::length(s1, s2) as f64,
         "smith_waterman" => textdistance::str::smith_waterman(s1, s2) as f64,
         #[cfg(feature = "std")]
-        "entropy_ncd" => textdistance::str::entropy_ncd(s1, s2) as f64,
+        "entropy_ncd" => textdistance::str::entropy_ncd(s1, s2),
         #[cfg(feature = "std")]
         "roberts" => textdistance::str::roberts(s1, s2),
         _ => panic!("unknown algorithm name"),

--- a/src/nstr.rs
+++ b/src/nstr.rs
@@ -1,33 +1,7 @@
 //! Helper functions providing the default normalized implementation of distance/similarity algorithms for strings.
 //!
 //! See also [`textdistance::str`](super::str) for non-normalized distance.
-
-use super::Algorithm;
-use super::Bag;
-use super::Cosine;
-use super::DamerauLevenshtein;
-use super::EntropyNCD;
-use super::Hamming;
-use super::Jaccard;
-use super::Jaro;
-use super::JaroWinkler;
-use super::LCSSeq;
-use super::LCSStr;
-use super::Length;
-use super::Levenshtein;
-use super::Overlap;
-use super::Prefix;
-use super::RatcliffObershelp;
-use super::Roberts;
-use super::Sift4Common;
-use super::Sift4Simple;
-use super::SmithWaterman;
-use super::SorensenDice;
-use super::Suffix;
-use super::Tversky;
-use super::YujianBo;
-use super::LIG3;
-use super::MLIPNS;
+use super::*;
 
 /// Calculate normalized unrestricted [Damerau-Levenshtein distance][1] for two strings.
 ///
@@ -37,6 +11,7 @@ use super::MLIPNS;
 ///     assert!(damerau_levenshtein("abc", "acbd") == 2./4.); // "bc" swapped and "d" added
 ///
 /// [1]: https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
+#[cfg(feature = "std")]
 pub fn damerau_levenshtein(s1: &str, s2: &str) -> f64 {
     DamerauLevenshtein::default().for_str(s1, s2).nval()
 }
@@ -49,6 +24,7 @@ pub fn damerau_levenshtein(s1: &str, s2: &str) -> f64 {
 ///     assert!(damerau_levenshtein("abc", "acbd") == 2./4.); // "bc" swapped and "d" added
 ///
 /// [1]: https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
+#[cfg(feature = "std")]
 pub fn damerau_levenshtein_restricted(s1: &str, s2: &str) -> f64 {
     let a = DamerauLevenshtein {
         restricted: true,
@@ -197,6 +173,7 @@ pub fn mlipns(s1: &str, s2: &str) -> f64 {
 ///     assert!(bag("abc", "acbd") == 1./4.);
 ///
 /// [1]: http://www-db.disi.unibo.it/research/papers/SPIRE02.pdf
+#[cfg(feature = "std")]
 pub fn bag(s1: &str, s2: &str) -> f64 {
     Bag::default().for_str(s1, s2).nval()
 }
@@ -221,6 +198,7 @@ pub fn lig3(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(jaccard("abc", "acbd"), 0.75);
 ///
 /// [1]: https://en.wikipedia.org/wiki/Jaccard_index
+#[cfg(feature = "std")]
 pub fn jaccard(s1: &str, s2: &str) -> f64 {
     Jaccard::default().for_str(s1, s2).nval()
 }
@@ -233,6 +211,7 @@ pub fn jaccard(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(sorensen_dice("abc", "acbd"), 0.8571428571428571);
 ///
 /// [1]:https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient
+#[cfg(feature = "std")]
 pub fn sorensen_dice(s1: &str, s2: &str) -> f64 {
     SorensenDice::default().for_str(s1, s2).nval()
 }
@@ -245,6 +224,7 @@ pub fn sorensen_dice(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(tversky("abc", "acbd"), 0.75);
 ///
 /// [1]: https://en.wikipedia.org/wiki/Tversky_index
+#[cfg(feature = "std")]
 pub fn tversky(s1: &str, s2: &str) -> f64 {
     Tversky::default().for_str(s1, s2).nval()
 }
@@ -257,6 +237,7 @@ pub fn tversky(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(overlap("abc", "acbd"), 1.0);
 ///
 /// [1]: https://en.wikipedia.org/wiki/Overlap_coefficient
+#[cfg(feature = "std")]
 pub fn overlap(s1: &str, s2: &str) -> f64 {
     Overlap::default().for_str(s1, s2).nval()
 }
@@ -269,6 +250,7 @@ pub fn overlap(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(cosine("abc", "acbd"), 0.8660254037844387);
 ///
 /// [1]: https://en.wikipedia.org/wiki/Cosine_similarity
+#[cfg(feature = "std")]
 pub fn cosine(s1: &str, s2: &str) -> f64 {
     Cosine::default().for_str(s1, s2).nval()
 }
@@ -327,6 +309,7 @@ pub fn smith_waterman(s1: &str, s2: &str) -> f64 {
 ///
 /// [1]: https://en.wikipedia.org/wiki/Normalized_compression_distance
 /// [Entropy]: https://en.wikipedia.org/wiki/Entropy_(information_theory)
+#[cfg(feature = "std")]
 pub fn entropy_ncd(s1: &str, s2: &str) -> f64 {
     EntropyNCD::default().for_str(s1, s2).nval()
 }
@@ -339,6 +322,7 @@ pub fn entropy_ncd(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(roberts("abc", "acbd"), 0.8571428571428571);
 ///
 /// [Roberts similarity]: https://github.com/chrislit/abydos/blob/master/abydos/distance/_roberts.py
+#[cfg(feature = "std")]
 pub fn roberts(s1: &str, s2: &str) -> f64 {
     Roberts::default().for_str(s1, s2).nval()
 }

--- a/src/str.rs
+++ b/src/str.rs
@@ -2,32 +2,7 @@
 //!
 //! See also [`textdistance::nstr`](super::nstr) for normalized distance.
 
-use super::Algorithm;
-use super::Bag;
-use super::Cosine;
-use super::DamerauLevenshtein;
-use super::EntropyNCD;
-use super::Hamming;
-use super::Jaccard;
-use super::Jaro;
-use super::JaroWinkler;
-use super::LCSSeq;
-use super::LCSStr;
-use super::Length;
-use super::Levenshtein;
-use super::Overlap;
-use super::Prefix;
-use super::RatcliffObershelp;
-use super::Roberts;
-use super::Sift4Common;
-use super::Sift4Simple;
-use super::SmithWaterman;
-use super::SorensenDice;
-use super::Suffix;
-use super::Tversky;
-use super::YujianBo;
-use super::LIG3;
-use super::MLIPNS;
+use super::*;
 
 /// Calculate unrestricted [Damerau-Levenshtein distance][1] for two strings.
 ///
@@ -37,6 +12,7 @@ use super::MLIPNS;
 ///     assert!(damerau_levenshtein("abc", "acbd") == 2); // "bc" swapped and "d" added
 ///
 /// [1]: https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
+#[cfg(feature = "std")]
 pub fn damerau_levenshtein(s1: &str, s2: &str) -> usize {
     DamerauLevenshtein::default().for_str(s1, s2).val()
 }
@@ -49,6 +25,7 @@ pub fn damerau_levenshtein(s1: &str, s2: &str) -> usize {
 ///     assert!(damerau_levenshtein("abc", "acbd") == 2); // "bc" swapped and "d" added
 ///
 /// [1]: https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
+#[cfg(feature = "std")]
 pub fn damerau_levenshtein_restricted(s1: &str, s2: &str) -> usize {
     let a = DamerauLevenshtein {
         restricted: true,
@@ -197,6 +174,7 @@ pub fn mlipns(s1: &str, s2: &str) -> usize {
 ///     assert!(bag("abc", "acbd") == 1);
 ///
 /// [1]: http://www-db.disi.unibo.it/research/papers/SPIRE02.pdf
+#[cfg(feature = "std")]
 pub fn bag(s1: &str, s2: &str) -> usize {
     Bag::default().for_str(s1, s2).val()
 }
@@ -221,6 +199,7 @@ pub fn lig3(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(jaccard("abc", "acbd"), 0.75);
 ///
 /// [1]: https://en.wikipedia.org/wiki/Jaccard_index
+#[cfg(feature = "std")]
 pub fn jaccard(s1: &str, s2: &str) -> f64 {
     Jaccard::default().for_str(s1, s2).nval()
 }
@@ -233,6 +212,7 @@ pub fn jaccard(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(sorensen_dice("abc", "acbd"), 0.8571428571428571);
 ///
 /// [1]:https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient
+#[cfg(feature = "std")]
 pub fn sorensen_dice(s1: &str, s2: &str) -> f64 {
     SorensenDice::default().for_str(s1, s2).nval()
 }
@@ -245,6 +225,7 @@ pub fn sorensen_dice(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(tversky("abc", "acbd"), 0.75);
 ///
 /// [1]: https://en.wikipedia.org/wiki/Tversky_index
+#[cfg(feature = "std")]
 pub fn tversky(s1: &str, s2: &str) -> f64 {
     Tversky::default().for_str(s1, s2).nval()
 }
@@ -257,6 +238,7 @@ pub fn tversky(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(overlap("abc", "acbd"), 1.0);
 ///
 /// [1]: https://en.wikipedia.org/wiki/Overlap_coefficient
+#[cfg(feature = "std")]
 pub fn overlap(s1: &str, s2: &str) -> f64 {
     Overlap::default().for_str(s1, s2).nval()
 }
@@ -269,6 +251,7 @@ pub fn overlap(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(cosine("abc", "acbd"), 0.8660254037844387);
 ///
 /// [1]: https://en.wikipedia.org/wiki/Cosine_similarity
+#[cfg(feature = "std")]
 pub fn cosine(s1: &str, s2: &str) -> f64 {
     Cosine::default().for_str(s1, s2).nval()
 }
@@ -327,6 +310,7 @@ pub fn smith_waterman(s1: &str, s2: &str) -> usize {
 ///
 /// [1]: https://en.wikipedia.org/wiki/Normalized_compression_distance
 /// [Entropy]: https://en.wikipedia.org/wiki/Entropy_(information_theory)
+#[cfg(feature = "std")]
 pub fn entropy_ncd(s1: &str, s2: &str) -> f64 {
     EntropyNCD::default().for_str(s1, s2).nval()
 }
@@ -339,6 +323,7 @@ pub fn entropy_ncd(s1: &str, s2: &str) -> f64 {
 ///     assert_eq!(roberts("abc", "acbd"), 0.8571428571428571);
 ///
 /// [Roberts similarity]: https://github.com/chrislit/abydos/blob/master/abydos/distance/_roberts.py
+#[cfg(feature = "std")]
 pub fn roberts(s1: &str, s2: &str) -> f64 {
     Roberts::default().for_str(s1, s2).nval()
 }


### PR DESCRIPTION
Add support for `#![no_std]` projects. Some algorithms require HasMap, which is not available in the alloc crate, so these algorithms are disabled if `std` feature is turned off.