### PR TITLE
Fix underflow in Sift4Common

### DIFF
--- a/src/algorithms/sift4_common.rs
+++ b/src/algorithms/sift4_common.rs
@@ -165,6 +165,9 @@ mod tests {
     #[case("aaaa", "abbb", 3)]
     #[case("123 nowhere ave", "123 n0where 4ve", 2)]
     #[case("bisectable6", "disectable6", 1)]
+    // Non-ASCII regression tests
+    #[case("aaaaaa |", "baaaaa", 3)]
+    #[case("/", "®/", 1)]
     fn function_str(#[case] s1: &str, #[case] s2: &str, #[case] exp: usize) {
         assert!(sift4_common(s1, s2) == exp);
     }


### PR DESCRIPTION
I'm running the `Sift4Common` distance over results of OCR, which are often quite noisy. I've found some strings in the wild which cause a panic in debug mode, because of a subtraction with underflow.

I haven't actually fixed the bug yet (hence the draft status), but I've added some failing tests for the moment. I'll keep digging to identify the root cause and a fix.